### PR TITLE
Kn/refcatoring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,6 @@ it only should implement ``clear`` method which is invoked after tearDown.
 ``InMemoryStorageMixin`` cannot be used with bare ``unittest.TestCase``,
 you have to use ``TestCase`` from Django or ``ViewTestCase`` from **djet**.
 
-Other utils
------------
-
-``utils.refresh`` helps you get newer version of object from database
-in a very simple way.
 
 Examples
 ========
@@ -216,8 +211,8 @@ Utils example:
 
             self.view(request)
 
-            changed_flower = utils.refresh(flower)
-            self.assertEqual('blue', changed_flower.color)
+            flower.refresh_from_db()
+            self.assertEqual('blue', flower.color)
 
 Below there is an example of Django REST Framework authentication mocking. Pay attantion to ``djet.restframework.APIViewTestCase`` base class and ``user`` parameter in request factory call.
 
@@ -243,7 +238,7 @@ Below there is an example of Django REST Framework authentication mocking. Pay a
             response = self.view(request)
     
             self.assert_status_equal(response, status.HTTP_200_OK)
-            user = utils.refresh(user)
+            user.refresh_from_db()
             self.assertEqual(data['new_username'], user.username)
 
 For more comprehensive examples we really recommend to `check out how djoser library tests are crafted <https://github.com/sunscrapers/djoser/blob/master/testproject/testapp/tests.py>`__.

--- a/djet/utils.py
+++ b/djet/utils.py
@@ -1,2 +1,0 @@
-def refresh(instance):
-    return instance.__class__._default_manager.get(pk=instance.pk)

--- a/testproject/tests/tests/test_restframework.py
+++ b/testproject/tests/tests/test_restframework.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.core.handlers.wsgi import WSGIRequest
 from rest_framework import generics, authentication, permissions, status, serializers
 from tests import models
-from djet import assertions, files, utils, restframework as djet_restframework
+from djet import assertions, files, restframework as djet_restframework
 
 
 class APIRequestFactoryTest(django_test.TestCase):
@@ -88,7 +88,7 @@ class RetrieveUpdateAPIViewTestCaseTest(assertions.StatusCodeAssertionsMixin, dj
         response = self.view(request, pk=instance.pk)
 
         self.assert_status_equal(response, status.HTTP_200_OK)
-        instance = utils.refresh(instance)
+        instance.refresh_from_db()
         self.assertEqual(instance.field, data['field'])
 
 

--- a/testproject/tests/tests/test_utils.py
+++ b/testproject/tests/tests/test_utils.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-from djet import utils
 from tests import models
 
 
@@ -10,5 +9,5 @@ class RefreshTest(TestCase):
 
         models.MockModel.objects.filter(pk=instance.pk).update(field='new')
 
-        instance = utils.refresh(instance)
+        instance.refresh_from_db()
         self.assertEqual(instance.field, 'new')


### PR DESCRIPTION
Refactored `load_middleware` method on pair programming with Przemek.
Also noticed that `utils.refresh` is not needed because django model instances already have `refresh_from_db`