### PR TITLE
changed the source of importing 'six' library

### DIFF
--- a/djet/files.py
+++ b/djet/files.py
@@ -1,8 +1,9 @@
 import os
 import datetime
+
+import six
 from django.core.files.storage import Storage, default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.utils import six
 
 
 class InMemoryStorage(Storage):


### PR DESCRIPTION
Django 3.0 don't support django.utils.six library.
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis